### PR TITLE
Sets append_dot_mydomain = no

### DIFF
--- a/templates/postfix.conf
+++ b/templates/postfix.conf
@@ -6,6 +6,7 @@ smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_una
 myhostname = {{ FORWARD_MAIL_MYDOMAIN }}
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
+append_dot_mydomain = no
 sender_canonical_maps = hash:/etc/postfix/canonical
 myorigin = {{ FORWARD_MAIL_MYDOMAIN }}
 mydestination = localhost, {{ FORWARD_MAIL_MYDOMAIN }}


### PR DESCRIPTION
We're experiencing an issue with `mdadm`'s default configuration, whose default configuration sends alert emails to `MAILADDR root@localhost`.

Because we're currently using `postfix`'s [backward-compatible setting for `append_dot_mydomain = yes`](http://www.postfix.org/COMPATIBILITY_README.html#append_dot_mydomain), emails addressed to `root@localhost` get rewritten to `root@localhost.$mydomain`, which in our case, is `root@localhost.opencraft.hosting`.  Since there is no `localhost.opencraft.hosting`, these messages get lost.

This change ensures emails addressed to `root@localhost` are actually sent to `root@localhost`, so they can be subsequently forwarded to `FORWARD_MAIL_RELAY_MAIL_TO` via the [alias defined in `/etc/aliases`](https://github.com/open-craft/ansible-forward-server-mail/blob/master/templates/aliases#L1).

**Test Instructions**

1. Ensure the `append_dot_mydomain = no` setting gets added to [`/etc/postfix/main.cf`](https://github.com/open-craft/ansible-forward-server-mail/blob/master/tasks/main.yml#L7), and [`postfix restart`](https://github.com/open-craft/ansible-forward-server-mail/blob/master/tasks/main.yml#L28) was run.
1. Run `sudo mdadm --monitor --scan --test -1` while watching `/var/log/syslog`, to ensure that the email gets sent to `root@localhost`, then to the configured `FORWARD_MAIL_RELAY_MAIL_TO`.
1. Check the inbox for `FORWARD_MAIL_RELAY_MAIL_TO` to ensure the test message was received.

**Reviewer**

- [ ] @itsjeyd 